### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/src/main/java/de/mprengemann/intellij/plugin/androidicons/util/AndroidFacetUtils.java
+++ b/src/main/java/de/mprengemann/intellij/plugin/androidicons/util/AndroidFacetUtils.java
@@ -31,6 +31,9 @@ import java.util.Iterator;
 import java.util.List;
 
 public class AndroidFacetUtils {
+    private AndroidFacetUtils() {
+    }
+
     public static AndroidFacet getCurrentFacet(Project project, Module module) {
         AndroidFacet currentFacet = null;
         if (module == null) {

--- a/src/main/java/de/mprengemann/intellij/plugin/androidicons/util/ExportNameUtils.java
+++ b/src/main/java/de/mprengemann/intellij/plugin/androidicons/util/ExportNameUtils.java
@@ -22,7 +22,10 @@ import java.util.List;
 import java.util.Set;
 
 public class ExportNameUtils {
-    
+
+    private ExportNameUtils() {
+    }
+
     public static String getExportNameFromFilename(String filename) {
         String exportName = FilenameUtils.removeExtension(filename);
         if (exportName.matches("[a-z0-9_.]*")) {

--- a/src/main/java/de/mprengemann/intellij/plugin/androidicons/util/ImageUtils.java
+++ b/src/main/java/de/mprengemann/intellij/plugin/androidicons/util/ImageUtils.java
@@ -35,6 +35,9 @@ import java.util.List;
 
 public class ImageUtils {
 
+    private ImageUtils() {
+    }
+
     public static void updateImage(JLabel imageContainer, File imageFile, Format format) {
         if (imageFile == null || !imageFile.exists()) {
             return;

--- a/src/main/java/de/mprengemann/intellij/plugin/androidicons/util/MathUtils.java
+++ b/src/main/java/de/mprengemann/intellij/plugin/androidicons/util/MathUtils.java
@@ -14,6 +14,9 @@
 package de.mprengemann.intellij.plugin.androidicons.util;
 
 public class MathUtils {
+    private MathUtils() {
+    }
+
     public static boolean floatEquals(float a, float b) {
         return Float.compare(a, b) == 0;
     }

--- a/src/main/java/de/mprengemann/intellij/plugin/androidicons/util/RefactorUtils.java
+++ b/src/main/java/de/mprengemann/intellij/plugin/androidicons/util/RefactorUtils.java
@@ -25,6 +25,9 @@ public class RefactorUtils {
     private static final float FACTOR_XXXHDPI = 4f;
     private static final float FACTOR_TVDPI = 4f / 3f;
 
+    private RefactorUtils() {
+    }
+
     public static float getScaleFactor(Resolution target, Resolution baseLine) {
         switch (baseLine) {
             case MDPI:

--- a/src/main/java/de/mprengemann/intellij/plugin/androidicons/util/TextUtils.java
+++ b/src/main/java/de/mprengemann/intellij/plugin/androidicons/util/TextUtils.java
@@ -1,6 +1,9 @@
 package de.mprengemann.intellij.plugin.androidicons.util;
 
 public final class TextUtils {
+    private TextUtils() {
+    }
+
     public static boolean isEmpty(final CharSequence s) {
         return s == null || s.length() == 0;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.