### PR TITLE
Using Collection.isEmpty() to test for emptiness

### DIFF
--- a/src/main/java/de/mprengemann/intellij/plugin/androidicons/controllers/batchscale/BatchScaleImporterController.java
+++ b/src/main/java/de/mprengemann/intellij/plugin/androidicons/controllers/batchscale/BatchScaleImporterController.java
@@ -58,7 +58,7 @@ public class BatchScaleImporterController implements IBatchScaleImporterControll
     @Override
     public void addImage(Resolution sourceResolution, List<ImageInformation> imageInformation) {
         if (imageInformation == null ||
-            imageInformation.size() == 0) {
+                imageInformation.isEmpty()) {
             return;
         }
         final String sourcePath = imageInformation.get(0).getImageFile().getAbsolutePath();

--- a/src/main/java/de/mprengemann/intellij/plugin/androidicons/dialogs/AndroidBatchScaleImporter.java
+++ b/src/main/java/de/mprengemann/intellij/plugin/androidicons/dialogs/AndroidBatchScaleImporter.java
@@ -85,7 +85,7 @@ public class AndroidBatchScaleImporter extends DialogWrapper implements BatchSca
         @Override
         public void consume(final List<VirtualFile> virtualFiles) {
             if (virtualFiles == null ||
-                virtualFiles.size() == 0) {
+                    virtualFiles.isEmpty()) {
                 return;
             }
             final VirtualFile file = virtualFiles.get(0);

--- a/src/main/java/de/mprengemann/intellij/plugin/androidicons/dialogs/AndroidMultiDrawableImporter.java
+++ b/src/main/java/de/mprengemann/intellij/plugin/androidicons/dialogs/AndroidMultiDrawableImporter.java
@@ -347,7 +347,7 @@ public class AndroidMultiDrawableImporter extends DialogWrapper implements Multi
                     int foundAssets = 0;
                     for (Resolution resolution : zipImages.keySet()) {
                         final List<ImageInformation> assetInformation = zipImages.get(resolution);
-                        if (assetInformation != null && assetInformation.size() > 0) {
+                        if (assetInformation != null && !assetInformation.isEmpty()) {
                             foundAssets += assetInformation.size();
                             foundResolutions.add(resolution);
                         }
@@ -358,7 +358,7 @@ public class AndroidMultiDrawableImporter extends DialogWrapper implements Multi
                     UIUtil.invokeLaterIfNeeded(new DumbAwareRunnable() {
                         public void run() {
                             final String title = String.format("Import '%s'", archiveName);
-                            if (foundResolutions.size() == 0 || finalFoundAssets == 0) {
+                            if (foundResolutions.isEmpty() || finalFoundAssets == 0) {
                                 Messages.showErrorDialog("No assets found.", title);
                                 FileUtils.deleteQuietly(tempDir);
                                 return;

--- a/src/main/java/de/mprengemann/intellij/plugin/androidicons/images/RefactoringTask.java
+++ b/src/main/java/de/mprengemann/intellij/plugin/androidicons/images/RefactoringTask.java
@@ -96,7 +96,7 @@ public class RefactoringTask extends Task.Backgroundable {
 
     @Override
     public void run(@NotNull final ProgressIndicator progressIndicator) {
-        if (imageInformationList.size() == 0) {
+        if (imageInformationList.isEmpty()) {
             return;
         }
         this.progressIndicator = progressIndicator;
@@ -193,7 +193,7 @@ public class RefactoringTask extends Task.Backgroundable {
             }
         }
 
-        if (files.size() == dirs.size() && files.size() > 0) {
+        if (files.size() == dirs.size() && !files.isEmpty()) {
             selection = -1;
             RunnableUtils.runWriteCommand(project, new Runnable() {
                 @Override

--- a/src/main/java/de/mprengemann/intellij/plugin/androidicons/widgets/FileBrowserField.java
+++ b/src/main/java/de/mprengemann/intellij/plugin/androidicons/widgets/FileBrowserField.java
@@ -148,7 +148,7 @@ public class FileBrowserField extends TextFieldWithBrowseButton {
             @Override
             public void dropFiles(final List<VirtualFile> virtualFiles) {
                 if (virtualFiles == null ||
-                    virtualFiles.size() == 0) {
+                        virtualFiles.isEmpty()) {
                     return;
                 }
                 final VirtualFile file = virtualFiles.get(0);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
Ayman Abdelghany.