### PR TITLE
Use English locale for resolution case conversions

### DIFF
--- a/src/main/java/de/mprengemann/intellij/plugin/androidicons/controllers/icons/androidicons/AndroidIconsController.java
+++ b/src/main/java/de/mprengemann/intellij/plugin/androidicons/controllers/icons/androidicons/AndroidIconsController.java
@@ -7,6 +7,7 @@ import de.mprengemann.intellij.plugin.androidicons.resources.ResourceLoader;
 
 import java.io.File;
 import java.util.List;
+import java.util.Locale;
 
 public class AndroidIconsController implements IAndroidIconsController {
 
@@ -63,7 +64,7 @@ public class AndroidIconsController implements IAndroidIconsController {
         }
         final String localPath = String.format("%s/%s/%s.png",
                                                color,
-                                               resolution.toString().toLowerCase(),
+                                               resolution.toString().toLowerCase(Locale.ENGLISH),
                                                asset.getName());
         return ResourceLoader.getAssetResource(new File(iconPack.getPath(), localPath).getPath());
     }

--- a/src/main/java/de/mprengemann/intellij/plugin/androidicons/controllers/icons/materialicons/MaterialIconsController.java
+++ b/src/main/java/de/mprengemann/intellij/plugin/androidicons/controllers/icons/materialicons/MaterialIconsController.java
@@ -11,6 +11,7 @@ import de.mprengemann.intellij.plugin.androidicons.resources.ResourceLoader;
 import java.io.File;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 public class MaterialIconsController implements IMaterialIconsController {
@@ -96,7 +97,7 @@ public class MaterialIconsController implements IMaterialIconsController {
     private String getImageFilePath(ImageAsset asset, String color, String size, Resolution resolution) {
         return String.format("%s/drawable-%s/%s_%s_%s.png",
                                                asset.getCategory(),
-                                               resolution.toString().toLowerCase(),
+                                               resolution.toString().toLowerCase(Locale.ENGLISH),
                                                asset.getName(),
                                                color,
                                                size);
@@ -105,7 +106,7 @@ public class MaterialIconsController implements IMaterialIconsController {
     private String getVectorFilePath(ImageAsset asset) {
         return String.format("%s/drawable-%s-v21/%s_black_24dp.xml",
                              asset.getCategory(),
-                             Resolution.ANYDPI.toString().toLowerCase(),
+                             Resolution.ANYDPI.toString().toLowerCase(Locale.ENGLISH),
                              asset.getName());
     }
 

--- a/src/main/java/de/mprengemann/intellij/plugin/androidicons/model/ImageInformation.java
+++ b/src/main/java/de/mprengemann/intellij/plugin/androidicons/model/ImageInformation.java
@@ -18,6 +18,7 @@ import de.mprengemann.intellij.plugin.androidicons.controllers.defaults.Defaults
 import de.mprengemann.intellij.plugin.androidicons.images.ResizeAlgorithm;
 
 import java.io.File;
+import java.util.Locale;
 
 public class ImageInformation {
 
@@ -69,7 +70,9 @@ public class ImageInformation {
     }
 
     public File getTempImage() {
-        return new File(getTempDir(), String.format("%s/%s", targetResolution.toString().toLowerCase(), exportName));
+        return new File(getTempDir(), String.format("%s/%s",
+                                                    targetResolution.toString().toLowerCase(Locale.ENGLISH),
+                                                    exportName));
     }
 
     public File getImageFile() {
@@ -111,7 +114,7 @@ public class ImageInformation {
     public File getTargetFile() {
         return new File(String.format(TARGET_FILE_PATTERN,
                                       exportPath,
-                                      targetResolution.toString().toLowerCase(),
+                                      targetResolution.toString().toLowerCase(Locale.ENGLISH),
                                       exportName,
                                       format.toString().toLowerCase()));
     }


### PR DESCRIPTION
This commit fixes a bug when the application runs on an environment with Turkish locale. Turkish have two separate "i" character dotted and dotless. Per the Unicode standard, our lowercase "i" becomes "İ" (U+0130 "Latin Capital Letter I With Dot Above") when it moves to uppercase. Similarly, our uppercase "I" becomes "ı" (U+0131 "Latin Small Letter Dotless I") when it moves to lowercase. Using English locale prevents case conversion with an incorrect locale.

In example:
```
HDPI.toString().toLowerCase()                 // Output: hdpı
HDPI.toString().toLowerCase(Locale.ENGLISH)   // Output: hdpi
```

For additional info, you can check out the links below:
http://www.moserware.com/2008/02/does-your-code-pass-turkey-test.html
https://blog.codinghorror.com/whats-wrong-with-turkey/
http://mattryall.net/blog/2009/02/the-infamous-turkish-locale-bug