### PR TITLE
Defect fixes for #142 and #135

### DIFF
--- a/src/main/java/de/mprengemann/intellij/plugin/androidicons/controllers/batchscale/additem/AddItemBatchScaleImporterController.java
+++ b/src/main/java/de/mprengemann/intellij/plugin/androidicons/controllers/batchscale/additem/AddItemBatchScaleImporterController.java
@@ -39,7 +39,7 @@ public class AddItemBatchScaleImporterController implements IAddItemBatchScaleIm
     private Format format;
 
     public AddItemBatchScaleImporterController(IDefaultsController defaultsController,
-                                               VirtualFile root,
+                                               String exportRoot,
                                                File file) {
         this.observers = new HashSet<AddItemBatchScaleDialogObserver>();
         this.targetResolutions = defaultsController.getResolutions();
@@ -50,11 +50,7 @@ public class AddItemBatchScaleImporterController implements IAddItemBatchScaleIm
         sourceResolution = defaultsController.getSourceResolution();
         algorithm = defaultsController.getAlgorithm();
         method = defaultsController.getMethod();
-        if (root != null) {
-            exportRoot = root.getCanonicalPath();
-        } else {
-            exportRoot = "";
-        }
+        this.exportRoot = exportRoot;
         isNinePatch = fileName.endsWith(".9.png");
         format = isNinePatch ? Format.PNG : defaultsController.getFormat();
     }

--- a/src/main/java/de/mprengemann/intellij/plugin/androidicons/dialogs/AddItemBatchScaleDialog.java
+++ b/src/main/java/de/mprengemann/intellij/plugin/androidicons/dialogs/AddItemBatchScaleDialog.java
@@ -18,6 +18,7 @@ import de.mprengemann.intellij.plugin.androidicons.listeners.SimpleKeyListener;
 import de.mprengemann.intellij.plugin.androidicons.model.Format;
 import de.mprengemann.intellij.plugin.androidicons.model.ImageInformation;
 import de.mprengemann.intellij.plugin.androidicons.model.Resolution;
+import de.mprengemann.intellij.plugin.androidicons.util.AndroidFacetUtils;
 import de.mprengemann.intellij.plugin.androidicons.util.ImageUtils;
 import de.mprengemann.intellij.plugin.androidicons.widgets.ExportNameField;
 import de.mprengemann.intellij.plugin.androidicons.widgets.FileBrowserField;
@@ -214,7 +215,13 @@ public class AddItemBatchScaleDialog extends DialogWrapper implements AddItemBat
 
     private void initController(File file) {
         final VirtualFile root = settingsController.getResourceRoot();
-        controller = new AddItemBatchScaleImporterController(defaultsController, root, file);
+        String exportRoot = "";
+        if (root != null) {
+            exportRoot = root.getCanonicalPath();
+        } else {
+            exportRoot = AndroidFacetUtils.getResourcesRoot(project, module);
+        }
+        controller = new AddItemBatchScaleImporterController(defaultsController, exportRoot, file);
     }
 
     private void initRequiredControllers() {

--- a/src/main/java/de/mprengemann/intellij/plugin/androidicons/dialogs/AndroidBatchScaleImporter.java
+++ b/src/main/java/de/mprengemann/intellij/plugin/androidicons/dialogs/AndroidBatchScaleImporter.java
@@ -41,6 +41,7 @@ import de.mprengemann.intellij.plugin.androidicons.controllers.batchscale.addite
 import de.mprengemann.intellij.plugin.androidicons.controllers.defaults.IDefaultsController;
 import de.mprengemann.intellij.plugin.androidicons.controllers.settings.ISettingsController;
 import de.mprengemann.intellij.plugin.androidicons.model.ImageInformation;
+import de.mprengemann.intellij.plugin.androidicons.util.AndroidFacetUtils;
 import de.mprengemann.intellij.plugin.androidicons.util.ImageUtils;
 import de.mprengemann.intellij.plugin.androidicons.util.MathUtils;
 import de.mprengemann.intellij.plugin.androidicons.widgets.FileBrowserField;
@@ -202,8 +203,14 @@ public class AndroidBatchScaleImporter extends DialogWrapper implements BatchSca
         final ISettingsController settingsController = container.getControllerFactory().getSettingsController();
         final IDefaultsController defaultsController = container.getControllerFactory().getDefaultsController();
         final VirtualFile root = settingsController.getResourceRoot();
+        String exportRoot = "";
+        if (root != null) {
+            exportRoot = root.getCanonicalPath();
+        } else {
+            exportRoot = AndroidFacetUtils.getResourcesRoot(project, module);
+        }
         final IAddItemBatchScaleImporterController addItemController =
-            new AddItemBatchScaleImporterController(defaultsController, root, realFile);
+            new AddItemBatchScaleImporterController(defaultsController, exportRoot, realFile);
         controller.addImage(addItemController.getSourceResolution(), addItemController.getImageInformation(project));
         addItemController.tearDown();
     }

--- a/src/main/java/de/mprengemann/intellij/plugin/androidicons/util/AndroidFacetUtils.java
+++ b/src/main/java/de/mprengemann/intellij/plugin/androidicons/util/AndroidFacetUtils.java
@@ -19,15 +19,9 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.LangDataKeys;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
-import com.intellij.psi.JavaDirectoryService;
-import com.intellij.psi.PsiDirectory;
-import com.intellij.psi.PsiElement;
+import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.android.facet.AndroidFacet;
-import org.jetbrains.android.util.AndroidUtils;
-import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 public class AndroidFacetUtils {
@@ -47,6 +41,17 @@ public class AndroidFacetUtils {
             }
         }
         return currentFacet;
+    }
+
+    public static String getResourcesRoot(Project project, Module module) {
+        final AndroidFacet currentFacet = AndroidFacetUtils.getCurrentFacet(project, module);
+        final List<VirtualFile> allResourceDirectories = currentFacet.getAllResourceDirectories();
+        String exportRoot = "";
+        if (allResourceDirectories.size() == 1) {
+            exportRoot = allResourceDirectories.get(0).getCanonicalPath();
+        }
+
+        return exportRoot;
     }
 
     public static void updateActionVisibility(AnActionEvent e) {


### PR DESCRIPTION
The Batch Import functionality should now detect and set the Android resource root as the target export root and no longer cause an IOException.

The IOException was caused when the batch import tool OKAction was invoked with target roots which were not set.  Essentially it thought it was going to write to `/drawable-whatever`, and interpreted that as creating a directory in `/`, which required root privileges.

I've tested the fix in Intellij Community Edition 2016.2.4 and Android Studio 2.2.